### PR TITLE
test(local-runtime): add ready apply regression for inbox consumer

### DIFF
--- a/contracts/planningops-local-operator-inbox-consumer-contract.md
+++ b/contracts/planningops-local-operator-inbox-consumer-contract.md
@@ -90,6 +90,7 @@ Top-level required fields:
 22. `source_artifacts.local_operator_report_path`
 
 Optional fields:
+- `runtime_input_overrides`
 - `runtime_report_summary`
 - `execution`
 
@@ -103,7 +104,8 @@ Optional fields:
    - otherwise true
 3. The generated mission file must preserve the promoted mission objective and mission packet id.
 4. The runtime command must be materialized as direct argv for `scripts/run_local_runtime_smoke.py`, not by shell parsing `monday_runtime_entrypoint_command`.
-5. `mode=apply` must refuse to execute when `can_launch` is false.
+5. When explicit runtime config override files are provided, the consumer must validate they exist and pass them through as `--planner-runtime-config` / `--runtime-profile-file`.
+6. `mode=apply` must refuse to execute when `can_launch` is false.
 
 ## Cross-Artifact Consistency Rules
 

--- a/scripts/consume_planningops_local_operator_inbox_payload.py
+++ b/scripts/consume_planningops_local_operator_inbox_payload.py
@@ -74,6 +74,19 @@ def resolve_existing_path(raw_path: object, label: str) -> Path:
     return path
 
 
+def resolve_optional_existing_path(raw_path: str | None, label: str) -> Path | None:
+    if raw_path is None:
+        return None
+    path = Path(raw_path)
+    if not path.is_absolute():
+        path = (REPO_ROOT / path).resolve()
+    else:
+        path = path.resolve()
+    if not path.exists():
+        raise SystemExit(f"{label} missing: {path}")
+    return path
+
+
 def build_block_reasons(*, payload_status: str, needs_human_attention: bool, local_validation_action_lines: list[str]) -> list[str]:
     reasons: list[str] = []
     if payload_status != "ready":
@@ -85,8 +98,16 @@ def build_block_reasons(*, payload_status: str, needs_human_attention: bool, loc
     return reasons
 
 
-def build_runtime_command(*, planner_profile: str, mission_file_path: Path, run_id: str, runtime_report_path: Path) -> list[str]:
-    return [
+def build_runtime_command(
+    *,
+    planner_profile: str,
+    mission_file_path: Path,
+    run_id: str,
+    runtime_report_path: Path,
+    planner_runtime_config: Path | None,
+    runtime_profile_file: Path | None,
+) -> list[str]:
+    command = [
         "python3",
         "scripts/run_local_runtime_smoke.py",
         "--profile",
@@ -98,6 +119,11 @@ def build_runtime_command(*, planner_profile: str, mission_file_path: Path, run_
         "--output",
         str(runtime_report_path.resolve()),
     ]
+    if planner_runtime_config is not None:
+        command.extend(["--planner-runtime-config", str(planner_runtime_config.resolve())])
+    if runtime_profile_file is not None:
+        command.extend(["--runtime-profile-file", str(runtime_profile_file.resolve())])
+    return command
 
 
 def parse_args() -> argparse.Namespace:
@@ -108,6 +134,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--run-id", default=f"planningops-local-inbox-consumer-{utc_timestamp_slug()}")
     parser.add_argument("--mode", choices=("dry-run", "apply"), default="dry-run")
     parser.add_argument("--output-root", default=str(DEFAULT_OUTPUT_ROOT))
+    parser.add_argument("--planner-runtime-config", default=None)
+    parser.add_argument("--runtime-profile-file", default=None)
     parser.add_argument("--output", default=None)
     return parser.parse_args()
 
@@ -135,6 +163,8 @@ def main() -> int:
     mission_file_path = run_root / "mission.json"
     runtime_report_path = run_root / "local-runtime-smoke.json"
     report_path = Path(args.output).resolve() if args.output else run_root / "consumer-report.json"
+    planner_runtime_config_path = resolve_optional_existing_path(args.planner_runtime_config, "planner runtime config")
+    runtime_profile_file_path = resolve_optional_existing_path(args.runtime_profile_file, "runtime profile file")
 
     bridge_doc = require_dict(load_json(bridge_path), "bridge payload")
     if require_string(bridge_doc.get("contract_ref"), "bridge contract ref") != PLANNINGOPS_BRIDGE_CONTRACT_REF:
@@ -212,6 +242,8 @@ def main() -> int:
         mission_file_path=mission_file_path,
         run_id=bridge_id,
         runtime_report_path=runtime_report_path,
+        planner_runtime_config=planner_runtime_config_path,
+        runtime_profile_file=runtime_profile_file_path,
     )
 
     launch_request = {
@@ -240,6 +272,15 @@ def main() -> int:
             "local_operator_report_path": str(local_operator_report_path.resolve()),
         },
     }
+    if planner_runtime_config_path is not None or runtime_profile_file_path is not None:
+        launch_request["runtime_input_overrides"] = {
+            "planner_runtime_config": None
+            if planner_runtime_config_path is None
+            else str(planner_runtime_config_path.resolve()),
+            "runtime_profile_file": None
+            if runtime_profile_file_path is None
+            else str(runtime_profile_file_path.resolve()),
+        }
     write_json(launch_request_path, launch_request)
 
     report = {

--- a/scripts/test_consume_planningops_local_operator_inbox_payload.sh
+++ b/scripts/test_consume_planningops_local_operator_inbox_payload.sh
@@ -18,7 +18,10 @@ ready_bridge_path="$planningops_validation/monday-local-operator-inbox-payload-r
 blocked_bridge_path="$planningops_validation/monday-local-operator-inbox-payload-blocked.json"
 output_root="$TMP_DIR/runtime-artifacts/integration/planningops-local-operator-inbox"
 dry_report="$TMP_DIR/consumer-dry-run.json"
+apply_ready_report="$TMP_DIR/consumer-apply-ready.json"
 blocked_report="$TMP_DIR/consumer-apply-blocked.json"
+runtime_profile_file="$TMP_DIR/runtime-profiles.json"
+planner_runtime_file="$TMP_DIR/planner-runtime.json"
 
 cat >"$mission_packet_path" <<'JSON'
 {
@@ -301,6 +304,133 @@ assert mission_file == {
 contract_text = Path("contracts/planningops-local-operator-inbox-consumer-contract.md").read_text(encoding="utf-8")
 assert "launch_request" in contract_text, contract_text
 assert "runtime_command_args" in contract_text, contract_text
+PY
+
+cat >"$runtime_profile_file" <<'JSON'
+{
+  "active_profile": "local",
+  "profiles": {
+    "local": {
+      "execution_mode": "local",
+      "litellm_base_url": "http://127.0.0.1:4000",
+      "langfuse_host": "http://127.0.0.1:3001"
+    }
+  }
+}
+JSON
+
+cat >"$planner_runtime_file" <<'JSON'
+{
+  "config_version": 1,
+  "active_profile": "local",
+  "profiles": {
+    "local": {
+      "planner_engine": "legacy"
+    }
+  }
+}
+JSON
+
+python3 - <<'PY' "$mission_packet_path" "$day_packet_path" "$ready_bridge_path"
+import json
+import sys
+from pathlib import Path
+
+mission_path = Path(sys.argv[1])
+day_path = Path(sys.argv[2])
+bridge_path = Path(sys.argv[3])
+
+mission_doc = json.loads(mission_path.read_text(encoding="utf-8"))
+mission_doc["mission_packet"]["planner_profile"] = "local"
+mission_doc["mission_packet"]["launch_mode"] = "stack"
+mission_doc["mission_packet"]["local_model_route"] = "gateway_first_local"
+mission_doc["mission_packet"]["preflight_command"] = "python3 planningops/scripts/run_monday_local_operator_stack.py --execution-mode stack --probe-endpoints on --run-id monday-local-mission-20260401T100000Z"
+mission_doc["mission_packet"]["monday_runtime_entrypoint_command"] = "cd ../monday && python3 scripts/run_local_runtime_smoke.py --profile local --run-id monday-local-mission-20260401T100000Z"
+mission_path.write_text(json.dumps(mission_doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+day_doc = json.loads(day_path.read_text(encoding="utf-8"))
+day_doc["day_packet"]["planner_profile"] = "local"
+day_doc["day_packet"]["launch_mode"] = "stack"
+day_doc["day_packet"]["local_model_route"] = "gateway_first_local"
+day_doc["day_packet"]["first_action_command"] = "python3 planningops/scripts/run_monday_local_operator_stack.py --execution-mode stack --probe-endpoints on --run-id monday-local-mission-20260401T100000Z"
+day_doc["day_packet"]["monday_runtime_entrypoint_command"] = "cd ../monday && python3 scripts/run_local_runtime_smoke.py --profile local --run-id monday-local-mission-20260401T100000Z"
+day_path.write_text(json.dumps(day_doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+bridge_doc = json.loads(bridge_path.read_text(encoding="utf-8"))
+bridge_doc["payload"]["planner_profile"] = "local"
+bridge_doc["payload"]["launch_mode"] = "stack"
+bridge_doc["payload"]["local_model_route"] = "gateway_first_local"
+bridge_doc["payload"]["monday_runtime_entrypoint_command"] = "cd ../monday && python3 scripts/run_local_runtime_smoke.py --profile local --run-id monday-local-mission-20260401T100000Z"
+bridge_path.write_text(json.dumps(bridge_doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+python3 "$ROOT_DIR/scripts/consume_planningops_local_operator_inbox_payload.py" \
+  --inbox-payload-file "$ready_bridge_path" \
+  --run-id "test-planningops-local-inbox-consumer-apply" \
+  --mode apply \
+  --planner-runtime-config "$planner_runtime_file" \
+  --runtime-profile-file "$runtime_profile_file" \
+  --output-root "$output_root" \
+  --output "$apply_ready_report"
+
+python3 - <<'PY' "$apply_ready_report" "$output_root" "$planner_runtime_file" "$runtime_profile_file"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+output_root = Path(sys.argv[2])
+planner_runtime_file = Path(sys.argv[3]).resolve()
+runtime_profile_file = Path(sys.argv[4]).resolve()
+mission_file_path = output_root / "test-planningops-local-inbox-consumer-apply" / "mission.json"
+runtime_report_path = output_root / "test-planningops-local-inbox-consumer-apply" / "local-runtime-smoke.json"
+
+assert report["verdict"] == "pass", report
+assert report["reason_code"] in {"ok", "tsx_fetch_unavailable_offline"}, report
+assert report["consumer_status"] == "ready_to_launch", report
+assert report["execution"]["attempted"] is True, report
+assert report["execution"]["exit_code"] == 0, report
+assert report["launch_request"]["can_launch"] is True, report
+assert report["launch_request"]["planner_profile"] == "local", report
+assert report["launch_request"]["launch_mode"] == "stack", report
+assert report["launch_request"]["local_model_route"] == "gateway_first_local", report
+assert report["launch_request"]["runtime_input_overrides"] == {
+    "planner_runtime_config": str(planner_runtime_file),
+    "runtime_profile_file": str(runtime_profile_file),
+}, report
+assert report["launch_request"]["runtime_command_args"] == [
+    "python3",
+    "scripts/run_local_runtime_smoke.py",
+    "--profile",
+    "local",
+    "--mission-file",
+    str(mission_file_path.resolve()),
+    "--run-id",
+    "monday-local-inbox-20260401T101000Z",
+    "--output",
+    str(runtime_report_path.resolve()),
+    "--planner-runtime-config",
+    str(planner_runtime_file),
+    "--runtime-profile-file",
+    str(runtime_profile_file),
+], report
+assert report["runtime_report_summary"]["report_path"] == str(runtime_report_path.resolve()), report
+assert report["runtime_report_summary"]["verdict"] in {"pass", "skip"}, report
+assert report["runtime_report_summary"]["reason_code"] in {"ok", "tsx_fetch_unavailable_offline"}, report
+PY
+
+python3 - <<'PY' "$blocked_bridge_path"
+import json
+import sys
+from pathlib import Path
+
+bridge_path = Path(sys.argv[1])
+bridge_doc = json.loads(bridge_path.read_text(encoding="utf-8"))
+bridge_doc["payload"]["planner_profile"] = "local"
+bridge_doc["payload"]["launch_mode"] = "stack"
+bridge_doc["payload"]["local_model_route"] = "gateway_first_local"
+bridge_doc["payload"]["monday_runtime_entrypoint_command"] = "cd ../monday && python3 scripts/run_local_runtime_smoke.py --profile local --run-id monday-local-mission-20260401T100000Z"
+bridge_path.write_text(json.dumps(bridge_doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
 PY
 
 python3 "$ROOT_DIR/scripts/consume_planningops_local_operator_inbox_payload.py" \


### PR DESCRIPTION
## Summary
- extend the monday inbox payload consumer regression to cover a ready apply-time launch
- pass deterministic runtime config override files through the consumer into run_local_runtime_smoke.py
- preserve blocked apply fail-closed behavior while proving a ready launch path

## Scope
- consumer contract update
- consumer script override passthrough
- consumer regression update for ready apply and blocked apply

## Linked Issues
- Closes #55
- Related PlanningOps: rather-not-work-on/platform-planningops#952

## Validation
- python3 -m py_compile scripts/consume_planningops_local_operator_inbox_payload.py
- bash scripts/test_consume_planningops_local_operator_inbox_payload.sh

## Risks
- runtime config overrides are introduced to make the ready apply regression deterministic; they should stay reviewed inputs and not turn into a casual operator escape hatch
- the ready apply regression currently proves the local runtime smoke path, not a deeper scheduler or delivery path

## Review Checklist
- [ ] Verify the consumer now forwards explicit runtime config override files into runtime argv
- [ ] Verify the ready apply regression executes run_local_runtime_smoke.py and records a runtime report summary
- [ ] Verify blocked apply behavior still stops before execution

## Post-Deploy Monitoring & Validation
- Re-run `bash scripts/test_consume_planningops_local_operator_inbox_payload.sh`
- Confirm the ready apply report continues to accept `verdict=pass` or upstream-compatible skip semantics when runtime prerequisites vary
