### PR TITLE
feat(local-runtime): add monday inbox schema validation

### DIFF
--- a/.github/workflows/monday-local-ci.yml
+++ b/.github/workflows/monday-local-ci.yml
@@ -88,6 +88,12 @@ jobs:
       - name: Verify mission-file local runtime smoke contract
         run: bash scripts/test_local_runtime_smoke_mission_file.sh
 
+      - name: Verify PlanningOps local inbox consumer contract
+        run: bash scripts/test_consume_planningops_local_operator_inbox_payload.sh
+
+      - name: Verify PlanningOps local inbox schema validation
+        run: bash scripts/test_validate_planningops_local_operator_inbox_artifacts.sh
+
       - name: Verify operator channel delivery CLI contract
         run: bash scripts/test_operator_channel_delivery_cli.sh
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -6,6 +6,8 @@ Define monday-owned runtime contract surfaces layered on top of shared platform 
 ## Contents
 - handoff field maps
 - runtime evidence schemas
+- planningops local inbox payload bridge acceptance schema
+- planningops local inbox consumer report schema
 - contract pin metadata
 
 ## Rules

--- a/contracts/planningops-local-operator-inbox-consumer-contract.md
+++ b/contracts/planningops-local-operator-inbox-consumer-contract.md
@@ -17,6 +17,7 @@ PlanningOps owns:
 
 Monday owns:
 - inbox bridge consumption
+- inbox payload and consumer report schema validation
 - launch-request materialization
 - optional apply-time execution through `scripts/run_local_runtime_smoke.py`
 - monday-side reports written under `runtime-artifacts/`
@@ -124,3 +125,7 @@ Optional fields:
 
 - `scripts/consume_planningops_local_operator_inbox_payload.py`
 - `scripts/test_consume_planningops_local_operator_inbox_payload.sh`
+- `contracts/planningops-local-operator-inbox-payload-bridge.schema.json`
+- `contracts/planningops-local-operator-inbox-consumer-report.schema.json`
+- `scripts/validate_planningops_local_operator_inbox_artifacts.py`
+- `scripts/test_validate_planningops_local_operator_inbox_artifacts.sh`

--- a/contracts/planningops-local-operator-inbox-consumer-report.schema.json
+++ b/contracts/planningops-local-operator-inbox-consumer-report.schema.json
@@ -1,0 +1,309 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "monday-planningops-local-operator-inbox-consumer-report",
+  "title": "PlanningOps Local Operator Inbox Consumer Report",
+  "type": "object",
+  "required": [
+    "generated_at_utc",
+    "run_id",
+    "consumer_contract_ref",
+    "source_bridge_path",
+    "bridge_id",
+    "mode",
+    "verdict",
+    "reason_code",
+    "consumer_status",
+    "artifact_paths",
+    "launch_request"
+  ],
+  "properties": {
+    "generated_at_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "consumer_contract_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_bridge_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "bridge_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "mode": {
+      "type": "string",
+      "enum": [
+        "dry-run",
+        "apply"
+      ]
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail",
+        "blocked"
+      ]
+    },
+    "reason_code": {
+      "type": "string",
+      "minLength": 1
+    },
+    "consumer_status": {
+      "type": "string",
+      "enum": [
+        "ready_to_launch",
+        "blocked"
+      ]
+    },
+    "artifact_paths": {
+      "type": "object",
+      "required": [
+        "launch_request_path",
+        "mission_file_path",
+        "runtime_report_path",
+        "report_path"
+      ],
+      "properties": {
+        "launch_request_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mission_file_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "runtime_report_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "report_path": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "launch_request": {
+      "type": "object",
+      "required": [
+        "source_bridge_id",
+        "source_day_packet_id",
+        "source_mission_packet_id",
+        "mission_objective",
+        "planner_profile",
+        "launch_mode",
+        "local_model_route",
+        "first_action_command",
+        "monday_runtime_entrypoint_command",
+        "rollback_command",
+        "recommended_wait_minutes",
+        "needs_human_attention",
+        "local_validation_snapshot_status",
+        "local_validation_summary_lines",
+        "local_validation_action_lines",
+        "can_launch",
+        "block_reasons",
+        "runtime_command_args",
+        "source_artifacts"
+      ],
+      "properties": {
+        "source_bridge_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_day_packet_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_mission_packet_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mission_objective": {
+          "type": "string",
+          "minLength": 1
+        },
+        "planner_profile": {
+          "type": "string",
+          "minLength": 1
+        },
+        "launch_mode": {
+          "type": "string",
+          "minLength": 1
+        },
+        "local_model_route": {
+          "type": "string",
+          "minLength": 1
+        },
+        "first_action_command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "monday_runtime_entrypoint_command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rollback_command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "recommended_wait_minutes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "needs_human_attention": {
+          "type": "boolean"
+        },
+        "local_validation_snapshot_status": {
+          "type": "string",
+          "minLength": 1
+        },
+        "local_validation_summary_lines": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "local_validation_action_lines": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "can_launch": {
+          "type": "boolean"
+        },
+        "block_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "runtime_command_args": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "runtime_input_overrides": {
+          "type": "object",
+          "required": [
+            "planner_runtime_config",
+            "runtime_profile_file"
+          ],
+          "properties": {
+            "planner_runtime_config": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "runtime_profile_file": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "source_artifacts": {
+          "type": "object",
+          "required": [
+            "day_packet_path",
+            "mission_packet_path",
+            "handoff_report_path",
+            "local_operator_report_path"
+          ],
+          "properties": {
+            "day_packet_path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "mission_packet_path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "handoff_report_path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "local_operator_report_path": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "runtime_report_summary": {
+      "type": "object",
+      "required": [
+        "verdict",
+        "reason_code",
+        "report_path"
+      ],
+      "properties": {
+        "verdict": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason_code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "report_path": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "execution": {
+      "type": "object",
+      "required": [
+        "attempted",
+        "command_args"
+      ],
+      "properties": {
+        "attempted": {
+          "type": "boolean"
+        },
+        "command_args": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "exit_code": {
+          "type": "integer"
+        },
+        "stdout": {
+          "type": "string"
+        },
+        "stderr": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/planningops-local-operator-inbox-payload-bridge.schema.json
+++ b/contracts/planningops-local-operator-inbox-payload-bridge.schema.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "monday-planningops-local-operator-inbox-payload-bridge",
+  "title": "PlanningOps Local Operator Inbox Payload Bridge",
+  "type": "object",
+  "required": [
+    "generated_at_utc",
+    "bridge_id",
+    "contract_ref",
+    "artifact_paths",
+    "payload"
+  ],
+  "properties": {
+    "generated_at_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "bridge_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "contract_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_paths": {
+      "type": "object",
+      "required": [
+        "latest_payload_path",
+        "stamped_payload_path",
+        "output_path"
+      ],
+      "properties": {
+        "latest_payload_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "stamped_payload_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "output_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "title",
+        "status",
+        "headline",
+        "priority_headline",
+        "operator_action",
+        "recommended_wait_minutes",
+        "retry_mode",
+        "needs_human_attention",
+        "message_class_hint",
+        "planner_profile",
+        "launch_mode",
+        "local_model_route",
+        "day_packet_id",
+        "mission_packet_id",
+        "mission_objective",
+        "first_action_command",
+        "monday_runtime_entrypoint_command",
+        "rollback_command",
+        "local_validation_snapshot_status",
+        "local_validation_summary_lines",
+        "local_validation_action_lines",
+        "queue_lines",
+        "target_lines",
+        "immediate_actions",
+        "attachments",
+        "body_markdown",
+        "bridge_contract_ref",
+        "source_artifacts"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "ready",
+            "blocked"
+          ]
+        },
+        "headline": {
+          "type": "string",
+          "minLength": 1
+        },
+        "priority_headline": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator_action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "recommended_wait_minutes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "retry_mode": {
+          "type": "string",
+          "minLength": 1
+        },
+        "needs_human_attention": {
+          "type": "boolean"
+        },
+        "message_class_hint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "planner_profile": {
+          "type": "string",
+          "minLength": 1
+        },
+        "launch_mode": {
+          "type": "string",
+          "minLength": 1
+        },
+        "local_model_route": {
+          "type": "string",
+          "minLength": 1
+        },
+        "day_packet_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mission_packet_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mission_objective": {
+          "type": "string",
+          "minLength": 1
+        },
+        "first_action_command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "monday_runtime_entrypoint_command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rollback_command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "local_validation_snapshot_status": {
+          "type": "string",
+          "minLength": 1
+        },
+        "local_validation_summary_lines": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "local_validation_action_lines": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "queue_lines": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "target_lines": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "immediate_actions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "attachments": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "body_markdown": {
+          "type": "string",
+          "minLength": 1
+        },
+        "bridge_contract_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_artifacts": {
+          "type": "object",
+          "required": [
+            "day_packet_path",
+            "mission_packet_path",
+            "handoff_report_path",
+            "local_operator_report_path"
+          ],
+          "properties": {
+            "day_packet_path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "mission_packet_path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "handoff_report_path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "local_operator_report_path": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/run_local_runtime_smoke.py
+++ b/scripts/run_local_runtime_smoke.py
@@ -144,6 +144,11 @@ def main():
         default="../platform-planningops/planningops/config/runtime-profiles.json",
         help="Path to the shared runtime profile catalog",
     )
+    parser.add_argument(
+        "--planner-runtime-config",
+        default=None,
+        help="Optional reviewed planner runtime config override recorded for auditability",
+    )
     parser.add_argument("--profile", default="local", help="Runtime profile id to resolve")
     parser.add_argument("--mission-id", default="local-mission-smoke", help="Mission id used for the smoke run")
     parser.add_argument(
@@ -172,6 +177,11 @@ def main():
     runtime_profile_file = (repo_root / args.runtime_profile_file).resolve()
     if not runtime_profile_file.exists():
         raise SystemExit(f"runtime profile file not found: {runtime_profile_file}")
+    planner_runtime_config = None
+    if args.planner_runtime_config:
+        planner_runtime_config = (repo_root / args.planner_runtime_config).resolve()
+        if not planner_runtime_config.exists():
+            raise SystemExit(f"planner runtime config not found: {planner_runtime_config}")
 
     mission, mission_source, mission_file = load_mission_input(repo_root, args.mission_file, args.mission_id, args.objective)
 
@@ -210,6 +220,7 @@ def main():
     report = {
         "generated_at_utc": now_utc(),
         "run_id": args.run_id,
+        "planner_runtime_config": None if planner_runtime_config is None else str(planner_runtime_config),
         "runtime_profile_file": str(runtime_profile_file),
         "mission_source": mission_source,
         "mission_file": mission_file,

--- a/scripts/test_consume_planningops_local_operator_inbox_payload.sh
+++ b/scripts/test_consume_planningops_local_operator_inbox_payload.sh
@@ -22,6 +22,11 @@ apply_ready_report="$TMP_DIR/consumer-apply-ready.json"
 blocked_report="$TMP_DIR/consumer-apply-blocked.json"
 runtime_profile_file="$TMP_DIR/runtime-profiles.json"
 planner_runtime_file="$TMP_DIR/planner-runtime.json"
+ready_bridge_validation="$TMP_DIR/ready-bridge-validation.json"
+blocked_bridge_validation="$TMP_DIR/blocked-bridge-validation.json"
+dry_report_validation="$TMP_DIR/dry-report-validation.json"
+apply_report_validation="$TMP_DIR/apply-report-validation.json"
+blocked_report_validation="$TMP_DIR/blocked-report-validation.json"
 
 cat >"$mission_packet_path" <<'JSON'
 {
@@ -262,6 +267,16 @@ python3 "$ROOT_DIR/scripts/consume_planningops_local_operator_inbox_payload.py" 
   --output-root "$output_root" \
   --output "$dry_report"
 
+python3 "$ROOT_DIR/scripts/validate_planningops_local_operator_inbox_artifacts.py" \
+  --kind bridge \
+  --artifact "$ready_bridge_path" \
+  --output "$ready_bridge_validation"
+
+python3 "$ROOT_DIR/scripts/validate_planningops_local_operator_inbox_artifacts.py" \
+  --kind consumer-report \
+  --artifact "$dry_report" \
+  --output "$dry_report_validation"
+
 python3 - <<'PY' "$dry_report" "$output_root"
 import json
 import sys
@@ -304,6 +319,18 @@ assert mission_file == {
 contract_text = Path("contracts/planningops-local-operator-inbox-consumer-contract.md").read_text(encoding="utf-8")
 assert "launch_request" in contract_text, contract_text
 assert "runtime_command_args" in contract_text, contract_text
+PY
+
+python3 - <<'PY' "$ready_bridge_validation" "$dry_report_validation"
+import json
+import sys
+from pathlib import Path
+
+ready_bridge_validation = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+dry_report_validation = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+
+assert ready_bridge_validation["verdict"] == "pass", ready_bridge_validation
+assert dry_report_validation["verdict"] == "pass", dry_report_validation
 PY
 
 cat >"$runtime_profile_file" <<'JSON'
@@ -373,6 +400,11 @@ python3 "$ROOT_DIR/scripts/consume_planningops_local_operator_inbox_payload.py" 
   --output-root "$output_root" \
   --output "$apply_ready_report"
 
+python3 "$ROOT_DIR/scripts/validate_planningops_local_operator_inbox_artifacts.py" \
+  --kind consumer-report \
+  --artifact "$apply_ready_report" \
+  --output "$apply_report_validation"
+
 python3 - <<'PY' "$apply_ready_report" "$output_root" "$planner_runtime_file" "$runtime_profile_file"
 import json
 import sys
@@ -419,6 +451,15 @@ assert report["runtime_report_summary"]["verdict"] in {"pass", "skip"}, report
 assert report["runtime_report_summary"]["reason_code"] in {"ok", "tsx_fetch_unavailable_offline"}, report
 PY
 
+python3 - <<'PY' "$apply_report_validation"
+import json
+import sys
+from pathlib import Path
+
+apply_report_validation = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert apply_report_validation["verdict"] == "pass", apply_report_validation
+PY
+
 python3 - <<'PY' "$blocked_bridge_path"
 import json
 import sys
@@ -440,6 +481,16 @@ python3 "$ROOT_DIR/scripts/consume_planningops_local_operator_inbox_payload.py" 
   --output-root "$output_root" \
   --output "$blocked_report"
 
+python3 "$ROOT_DIR/scripts/validate_planningops_local_operator_inbox_artifacts.py" \
+  --kind bridge \
+  --artifact "$blocked_bridge_path" \
+  --output "$blocked_bridge_validation"
+
+python3 "$ROOT_DIR/scripts/validate_planningops_local_operator_inbox_artifacts.py" \
+  --kind consumer-report \
+  --artifact "$blocked_report" \
+  --output "$blocked_report_validation"
+
 python3 - <<'PY' "$blocked_report"
 import json
 import sys
@@ -457,6 +508,18 @@ assert report["launch_request"]["block_reasons"] == [
     "local_validation_actions_present",
 ], report
 assert report["execution"]["attempted"] is False, report
+PY
+
+python3 - <<'PY' "$blocked_bridge_validation" "$blocked_report_validation"
+import json
+import sys
+from pathlib import Path
+
+blocked_bridge_validation = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+blocked_report_validation = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+
+assert blocked_bridge_validation["verdict"] == "pass", blocked_bridge_validation
+assert blocked_report_validation["verdict"] == "pass", blocked_report_validation
 PY
 
 echo "planningops local operator inbox consumer contract ok"

--- a/scripts/test_validate_planningops_local_operator_inbox_artifacts.sh
+++ b/scripts/test_validate_planningops_local_operator_inbox_artifacts.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+bridge_valid="$TMP_DIR/bridge-valid.json"
+bridge_invalid="$TMP_DIR/bridge-invalid.json"
+bridge_day="$TMP_DIR/day-packet.json"
+bridge_mission="$TMP_DIR/mission-packet.json"
+bridge_handoff="$TMP_DIR/handoff-report.json"
+bridge_operator="$TMP_DIR/local-operator-report.json"
+bridge_valid_report="$TMP_DIR/bridge-valid-report.json"
+bridge_invalid_report="$TMP_DIR/bridge-invalid-report.json"
+
+consumer_launch="$TMP_DIR/launch-request.json"
+consumer_mission="$TMP_DIR/mission.json"
+consumer_runtime="$TMP_DIR/runtime-report.json"
+consumer_valid="$TMP_DIR/consumer-valid.json"
+consumer_invalid="$TMP_DIR/consumer-invalid.json"
+consumer_valid_report="$TMP_DIR/consumer-valid-report.json"
+consumer_invalid_report="$TMP_DIR/consumer-invalid-report.json"
+
+cat >"$bridge_day" <<'JSON'
+{"day_packet_id":"day-1"}
+JSON
+cat >"$bridge_mission" <<'JSON'
+{"packet_id":"mission-1"}
+JSON
+cat >"$bridge_handoff" <<'JSON'
+{"record":{"headline":"Launch monday locally."}}
+JSON
+cat >"$bridge_operator" <<'JSON'
+{"readiness":{"status":"ready"}}
+JSON
+
+cat >"$bridge_valid" <<JSON
+{
+  "generated_at_utc": "2026-04-01T10:10:00Z",
+  "bridge_id": "monday-local-inbox-20260401T101000Z",
+  "contract_ref": "planningops/contracts/monday-local-operator-inbox-payload-bridge-contract.md",
+  "artifact_paths": {
+    "latest_payload_path": "$bridge_valid",
+    "stamped_payload_path": "$TMP_DIR/stamped-bridge.json",
+    "output_path": null
+  },
+  "payload": {
+    "title": "Monday local operator day packet",
+    "status": "ready",
+    "headline": "Monday local operator day packet",
+    "priority_headline": "Monday local operator day packet",
+    "operator_action": "launch_monday_local_runtime",
+    "recommended_wait_minutes": 0,
+    "retry_mode": "none",
+    "needs_human_attention": false,
+    "message_class_hint": "status_update",
+    "planner_profile": "local_ollama",
+    "launch_mode": "direct",
+    "local_model_route": "direct_local_ollama",
+    "day_packet_id": "day-1",
+    "mission_packet_id": "mission-1",
+    "mission_objective": "Resolve the next local monday runtime launch.",
+    "first_action_command": "python3 planningops/scripts/run_monday_local_operator_stack.py --execution-mode direct",
+    "monday_runtime_entrypoint_command": "python3 scripts/run_local_runtime_smoke.py --profile local_ollama",
+    "rollback_command": "bash scripts/litellm_stack_launcher.sh --mode start",
+    "local_validation_snapshot_status": "present",
+    "local_validation_summary_lines": [
+      "monday_local_operator_stack_report: freshness=fresh promotability=promotable"
+    ],
+    "local_validation_action_lines": [],
+    "queue_lines": [],
+    "target_lines": [
+      "monday local runtime smoke"
+    ],
+    "immediate_actions": [
+      "Run the monday local runtime smoke."
+    ],
+    "attachments": [
+      "$bridge_valid",
+      "$bridge_day"
+    ],
+    "body_markdown": "## Monday Local Operator Inbox Payload",
+    "bridge_contract_ref": "planningops/contracts/monday-local-operator-inbox-payload-bridge-contract.md",
+    "source_artifacts": {
+      "day_packet_path": "$bridge_day",
+      "mission_packet_path": "$bridge_mission",
+      "handoff_report_path": "$bridge_handoff",
+      "local_operator_report_path": "$bridge_operator"
+    }
+  }
+}
+JSON
+
+python3 "$ROOT_DIR/scripts/validate_planningops_local_operator_inbox_artifacts.py" \
+  --kind bridge \
+  --artifact "$bridge_valid" \
+  --output "$bridge_valid_report"
+
+cp "$bridge_valid" "$bridge_invalid"
+python3 - "$bridge_invalid" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+doc = json.loads(path.read_text(encoding="utf-8"))
+doc["contract_ref"] = "planningops/contracts/wrong-contract.md"
+doc["payload"]["source_artifacts"]["day_packet_path"] = str(path.parent / "missing-day-packet.json")
+path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+if python3 "$ROOT_DIR/scripts/validate_planningops_local_operator_inbox_artifacts.py" \
+  --kind bridge \
+  --artifact "$bridge_invalid" \
+  --output "$bridge_invalid_report"; then
+  echo "expected invalid bridge validation to fail"
+  exit 1
+fi
+
+cat >"$consumer_launch" <<JSON
+{
+  "source_bridge_id": "monday-local-inbox-20260401T101000Z",
+  "source_day_packet_id": "day-1",
+  "source_mission_packet_id": "mission-1",
+  "mission_objective": "Resolve the next local monday runtime launch.",
+  "planner_profile": "local_ollama",
+  "launch_mode": "direct",
+  "local_model_route": "direct_local_ollama",
+  "first_action_command": "python3 planningops/scripts/run_monday_local_operator_stack.py --execution-mode direct",
+  "monday_runtime_entrypoint_command": "python3 scripts/run_local_runtime_smoke.py --profile local_ollama",
+  "rollback_command": "bash scripts/litellm_stack_launcher.sh --mode start",
+  "recommended_wait_minutes": 0,
+  "needs_human_attention": false,
+  "local_validation_snapshot_status": "present",
+  "local_validation_summary_lines": [
+    "monday_local_operator_stack_report: freshness=fresh promotability=promotable"
+  ],
+  "local_validation_action_lines": [],
+  "can_launch": true,
+  "block_reasons": [],
+  "runtime_command_args": [
+    "python3",
+    "scripts/run_local_runtime_smoke.py",
+    "--profile",
+    "local_ollama"
+  ],
+  "runtime_input_overrides": {
+    "planner_runtime_config": "$TMP_DIR/planner-runtime.json",
+    "runtime_profile_file": "$TMP_DIR/runtime-profiles.json"
+  },
+  "source_artifacts": {
+    "day_packet_path": "$bridge_day",
+    "mission_packet_path": "$bridge_mission",
+    "handoff_report_path": "$bridge_handoff",
+    "local_operator_report_path": "$bridge_operator"
+  }
+}
+JSON
+cat >"$consumer_mission" <<'JSON'
+{"missionId":"mission-1","objective":"Resolve the next local monday runtime launch."}
+JSON
+cat >"$consumer_runtime" <<'JSON'
+{"verdict":"pass","reason_code":"ok"}
+JSON
+cat >"$TMP_DIR/planner-runtime.json" <<'JSON'
+{"config_version":1}
+JSON
+cat >"$TMP_DIR/runtime-profiles.json" <<'JSON'
+{"active_profile":"local"}
+JSON
+
+cat >"$consumer_valid" <<JSON
+{
+  "generated_at_utc": "2026-04-01T10:12:00Z",
+  "run_id": "planningops-local-inbox-consumer-20260401T101200Z",
+  "consumer_contract_ref": "contracts/planningops-local-operator-inbox-consumer-contract.md",
+  "source_bridge_path": "$bridge_valid",
+  "bridge_id": "monday-local-inbox-20260401T101000Z",
+  "mode": "apply",
+  "verdict": "pass",
+  "reason_code": "ok",
+  "consumer_status": "ready_to_launch",
+  "artifact_paths": {
+    "launch_request_path": "$consumer_launch",
+    "mission_file_path": "$consumer_mission",
+    "runtime_report_path": "$consumer_runtime",
+    "report_path": "$consumer_valid"
+  },
+  "launch_request": $(cat "$consumer_launch"),
+  "runtime_report_summary": {
+    "verdict": "pass",
+    "reason_code": "ok",
+    "report_path": "$consumer_runtime"
+  },
+  "execution": {
+    "attempted": true,
+    "command_args": [
+      "python3",
+      "scripts/run_local_runtime_smoke.py",
+      "--profile",
+      "local_ollama"
+    ],
+    "exit_code": 0,
+    "stdout": "ok",
+    "stderr": ""
+  }
+}
+JSON
+
+python3 "$ROOT_DIR/scripts/validate_planningops_local_operator_inbox_artifacts.py" \
+  --kind consumer-report \
+  --artifact "$consumer_valid" \
+  --output "$consumer_valid_report"
+
+cp "$consumer_valid" "$consumer_invalid"
+python3 - "$consumer_invalid" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+doc = json.loads(path.read_text(encoding="utf-8"))
+doc["consumer_contract_ref"] = "contracts/wrong-consumer-contract.md"
+doc["launch_request"]["source_bridge_id"] = "different-bridge-id"
+doc["mode"] = "dry-run"
+path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+if python3 "$ROOT_DIR/scripts/validate_planningops_local_operator_inbox_artifacts.py" \
+  --kind consumer-report \
+  --artifact "$consumer_invalid" \
+  --output "$consumer_invalid_report"; then
+  echo "expected invalid consumer report validation to fail"
+  exit 1
+fi
+
+python3 - "$bridge_valid_report" "$bridge_invalid_report" "$consumer_valid_report" "$consumer_invalid_report" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+bridge_valid = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+bridge_invalid = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+consumer_valid = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+consumer_invalid = json.loads(Path(sys.argv[4]).read_text(encoding="utf-8"))
+
+assert bridge_valid["verdict"] == "pass", bridge_valid
+assert bridge_valid["kind"] == "bridge", bridge_valid
+
+assert bridge_invalid["verdict"] == "fail", bridge_invalid
+bridge_errors = "\n".join(bridge_invalid["errors"])
+assert "bridge contract ref" in bridge_errors or "missing" in bridge_errors, bridge_invalid
+
+assert consumer_valid["verdict"] == "pass", consumer_valid
+assert consumer_valid["kind"] == "consumer-report", consumer_valid
+
+assert consumer_invalid["verdict"] == "fail", consumer_invalid
+consumer_errors = "\n".join(consumer_invalid["errors"])
+assert "consumer contract ref" in consumer_errors or "dry-run consumer report must not include execution" in consumer_errors, consumer_invalid
+PY
+
+echo "planningops local operator inbox artifact schema validation ok"

--- a/scripts/validate_planningops_local_operator_inbox_artifacts.py
+++ b/scripts/validate_planningops_local_operator_inbox_artifacts.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+from jsonschema_compat import load_validator_exports
+from runtime_evidence_contract import load_json
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLANNINGOPS_BRIDGE_CONTRACT_REF = "planningops/contracts/monday-local-operator-inbox-payload-bridge-contract.md"
+CONSUMER_CONTRACT_REF = "contracts/planningops-local-operator-inbox-consumer-contract.md"
+DEFAULT_SCHEMA_BY_KIND = {
+    "bridge": Path("contracts/planningops-local-operator-inbox-payload-bridge.schema.json"),
+    "consumer-report": Path("contracts/planningops-local-operator-inbox-consumer-report.schema.json"),
+}
+DEFAULT_OUTPUT_BY_KIND = {
+    "bridge": Path("runtime-artifacts/validation/planningops-local-operator-inbox-payload-validation-report.json"),
+    "consumer-report": Path("runtime-artifacts/validation/planningops-local-operator-inbox-consumer-report-validation-report.json"),
+}
+
+Draft202012Validator, FormatChecker, _SchemaError = load_validator_exports()
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def resolve_path(raw_path: str | Path) -> Path:
+    path = raw_path if isinstance(raw_path, Path) else Path(raw_path)
+    if path.is_absolute():
+        return path.resolve()
+    return (REPO_ROOT / path).resolve()
+
+
+def require_dict(value: object, label: str, *, errors: list[str]) -> dict:
+    if not isinstance(value, dict):
+        errors.append(f"{label} must be a JSON object")
+        return {}
+    return value
+
+
+def require_string(value: object, label: str, *, errors: list[str]) -> str:
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{label} must be a non-empty string")
+        return ""
+    return value.strip()
+
+
+def maybe_existing_path(raw_path: object) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    return resolve_path(raw_path)
+
+
+def validate_against_schema(doc: dict, schema_path: Path, *, errors: list[str]) -> None:
+    if not schema_path.exists():
+        errors.append(f"schema file not found: {schema_path}")
+        return
+    try:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"invalid schema JSON: {exc}")
+        return
+
+    try:
+        Draft202012Validator(schema, format_checker=FormatChecker()).validate(doc)
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"schema validation failed: {exc}")
+
+
+def validate_bridge_semantics(doc: dict) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if require_string(doc.get("contract_ref"), "contract_ref", errors=errors) != PLANNINGOPS_BRIDGE_CONTRACT_REF:
+        errors.append("bridge contract ref does not match planningops inbox payload bridge contract")
+
+    payload = require_dict(doc.get("payload"), "payload", errors=errors)
+    if require_string(payload.get("bridge_contract_ref"), "payload.bridge_contract_ref", errors=errors) != PLANNINGOPS_BRIDGE_CONTRACT_REF:
+        errors.append("payload bridge contract ref does not match planningops inbox payload bridge contract")
+
+    source_artifacts = require_dict(payload.get("source_artifacts"), "payload.source_artifacts", errors=errors)
+    for key in ("day_packet_path", "mission_packet_path", "handoff_report_path", "local_operator_report_path"):
+        artifact_path = maybe_existing_path(source_artifacts.get(key))
+        if artifact_path is None:
+            continue
+        if not artifact_path.exists():
+            errors.append(f"{key} missing: {artifact_path}")
+
+    attachments = payload.get("attachments")
+    if isinstance(attachments, list):
+        for attachment in attachments:
+            attachment_path = maybe_existing_path(attachment)
+            if attachment_path is not None and not attachment_path.exists():
+                warnings.append(f"attachment missing: {attachment_path}")
+
+    return errors, warnings
+
+
+def validate_consumer_report_semantics(doc: dict) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if require_string(doc.get("consumer_contract_ref"), "consumer_contract_ref", errors=errors) != CONSUMER_CONTRACT_REF:
+        errors.append("consumer contract ref does not match planningops local operator inbox consumer contract")
+
+    bridge_id = require_string(doc.get("bridge_id"), "bridge_id", errors=errors)
+    source_bridge_path = maybe_existing_path(doc.get("source_bridge_path"))
+    if source_bridge_path is not None and not source_bridge_path.exists():
+        errors.append(f"source bridge path missing: {source_bridge_path}")
+
+    mode = require_string(doc.get("mode"), "mode", errors=errors)
+    verdict = require_string(doc.get("verdict"), "verdict", errors=errors)
+    consumer_status = require_string(doc.get("consumer_status"), "consumer_status", errors=errors)
+
+    launch_request = require_dict(doc.get("launch_request"), "launch_request", errors=errors)
+    if require_string(launch_request.get("source_bridge_id"), "launch_request.source_bridge_id", errors=errors) != bridge_id:
+        errors.append("launch_request.source_bridge_id must match bridge_id")
+
+    source_artifacts = require_dict(launch_request.get("source_artifacts"), "launch_request.source_artifacts", errors=errors)
+    for key in ("day_packet_path", "mission_packet_path", "handoff_report_path", "local_operator_report_path"):
+        artifact_path = maybe_existing_path(source_artifacts.get(key))
+        if artifact_path is None:
+            continue
+        if not artifact_path.exists():
+            errors.append(f"launch_request.source_artifacts.{key} missing: {artifact_path}")
+
+    artifact_paths = require_dict(doc.get("artifact_paths"), "artifact_paths", errors=errors)
+    for key in ("launch_request_path", "mission_file_path", "report_path"):
+        artifact_path = maybe_existing_path(artifact_paths.get(key))
+        if artifact_path is None:
+            continue
+        if not artifact_path.exists():
+            errors.append(f"artifact_paths.{key} missing: {artifact_path}")
+
+    if mode == "dry-run" and "execution" in doc:
+        errors.append("dry-run consumer report must not include execution")
+    if mode == "apply" and not isinstance(doc.get("execution"), dict):
+        errors.append("apply consumer report must include execution")
+
+    execution = doc.get("execution")
+    if isinstance(execution, dict):
+        attempted = execution.get("attempted")
+        if attempted is True and mode != "apply":
+            errors.append("execution.attempted=true is only valid for apply mode")
+
+    runtime_report_summary = doc.get("runtime_report_summary")
+    if isinstance(runtime_report_summary, dict):
+        report_path = maybe_existing_path(runtime_report_summary.get("report_path"))
+        if report_path is not None and not report_path.exists():
+            errors.append(f"runtime_report_summary.report_path missing: {report_path}")
+
+    overrides = launch_request.get("runtime_input_overrides")
+    if isinstance(overrides, dict):
+        if not any(isinstance(overrides.get(key), str) and str(overrides.get(key)).strip() for key in ("planner_runtime_config", "runtime_profile_file")):
+            errors.append("runtime_input_overrides must include at least one non-empty override path")
+        for key in ("planner_runtime_config", "runtime_profile_file"):
+            override_path = maybe_existing_path(overrides.get(key))
+            if override_path is not None and not override_path.exists():
+                errors.append(f"launch_request.runtime_input_overrides.{key} missing: {override_path}")
+
+    if verdict == "blocked" and consumer_status != "blocked":
+        errors.append("blocked verdict must use consumer_status=blocked")
+
+    return errors, warnings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate monday-owned planningops local inbox payload and consumer report artifacts")
+    parser.add_argument("--kind", choices=sorted(DEFAULT_SCHEMA_BY_KIND), required=True)
+    parser.add_argument("--artifact", required=True)
+    parser.add_argument("--schema", default=None)
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    artifact_path = resolve_path(args.artifact)
+    schema_path = resolve_path(args.schema) if args.schema else resolve_path(DEFAULT_SCHEMA_BY_KIND[args.kind])
+    output_path = resolve_path(args.output) if args.output else resolve_path(DEFAULT_OUTPUT_BY_KIND[args.kind])
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    doc: dict = {}
+
+    if not artifact_path.exists():
+        errors.append(f"artifact file not found: {artifact_path}")
+    else:
+        try:
+            raw_doc = json.loads(artifact_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            errors.append(f"invalid artifact JSON: {exc}")
+        else:
+            if not isinstance(raw_doc, dict):
+                errors.append("artifact must be a JSON object")
+            else:
+                doc = raw_doc
+
+    if not errors:
+        validate_against_schema(doc, schema_path, errors=errors)
+
+    if not errors:
+        if args.kind == "bridge":
+            semantic_errors, semantic_warnings = validate_bridge_semantics(doc)
+        else:
+            semantic_errors, semantic_warnings = validate_consumer_report_semantics(doc)
+        errors.extend(semantic_errors)
+        warnings.extend(semantic_warnings)
+
+    verdict = "pass" if not errors else "fail"
+    report = {
+        "generated_at_utc": now_utc(),
+        "kind": args.kind,
+        "artifact_path": str(artifact_path),
+        "schema_path": str(schema_path),
+        "error_count": len(errors),
+        "warning_count": len(warnings),
+        "errors": errors,
+        "warnings": warnings,
+        "verdict": verdict,
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+    print(f"report written: {output_path}")
+    print(f"kind={args.kind} verdict={verdict} error_count={len(errors)} warning_count={len(warnings)}")
+    return 0 if verdict == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add monday-owned JSON schemas for the promoted PlanningOps inbox payload bridge and monday-native consumer report
- add a validator and invalid-case regression coverage for both artifact families
- wire the consumer and schema validation lane into monday local CI

## Scope
- Runtime/packages:
  - record reviewed planner runtime config overrides in `scripts/run_local_runtime_smoke.py`
- Scripts/contracts/docs:
  - add inbox payload and consumer report schemas
  - add `scripts/validate_planningops_local_operator_inbox_artifacts.py`
  - extend consumer regression and add schema validation regression
  - update contracts README and consumer contract guidance
- `.github/` workflows:
  - add local CI coverage for the consumer contract and schema validation lane

## Linked Issues
- Closes rather-not-work-on/monday#57
- Related rather-not-work-on/platform-planningops#960

## Validation
- [x] `bash scripts/test_local_runtime_smoke_mission_file.sh`
- [x] `bash scripts/test_consume_planningops_local_operator_inbox_payload.sh`
- [x] `bash scripts/test_validate_planningops_local_operator_inbox_artifacts.sh`
- [x] Additional checks (if any): `python3 -m py_compile scripts/run_local_runtime_smoke.py scripts/validate_planningops_local_operator_inbox_artifacts.py scripts/consume_planningops_local_operator_inbox_payload.py`

## Risks
- Risk: monday now pins the accepted PlanningOps bridge and emitted consumer report shapes more explicitly, so future cross-repo additive drift will need coordinated schema updates.
- Rollback: revert the schema validator/CI step and fall back to the existing script-level contract checks.

## Review Checklist
- [x] Changes are from a feature branch.
- [x] PR includes a repo-qualified planningops issue ref.
- [x] README or topology guidance updated if workflow expectations changed.
- [x] Validation commands were run locally.
